### PR TITLE
feat: add XHuntr — X (Twitter) community sniper for Solana alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,8 @@
   
  ## Projects building on Solana 
  see [solana.com/ecosystem](https://www.solana.com/ecosystem)
+
+ ## Trading & Alpha Tools
+
+ - [XHuntr](https://xhuntr.com) - The only X (Twitter) community sniper for Solana. Telegram bot that fires instant alerts when alpha hunters create or join X communities, post contract addresses before tweeting publicly, or when multiple tracked accounts converge on the same community.
+


### PR DESCRIPTION
Adds XHuntr to a new **Trading & Alpha Tools** section.

**XHuntr** is the only X community sniper for Solana — a Telegram bot that fires instant alerts when tracked alpha hunters:
- Create or join X communities (before any public tweet)
- Post contract addresses inside X communities (before the public call)  
- Trigger convergence events (2+ KOLs join same community simultaneously)

Fills the gap that wallet trackers don't cover: the social coordination layer that happens on X before any on-chain activity.

Site: https://xhuntr.com
Bot: https://t.me/XHuntrbot