### PR TITLE
Add GDEX Pro Solana trading terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
  - [Drift Protocol](https://www.drift.trade/) - Drift brings on-chain, cross-margined perpetual futures to Solana, making future DEXs the best way to trade.
  - [Mango](https://mango.markets/) - Mango is a decentralized, cross-margin trading platform with up to 5x leverage with integrated limit orders on Serum DEX’s on-chain order book.
  - [Hubble Protocol](https://hubbleprotocol.io/) - Hubble Protocol lets users borrow USDH against a basket of crypto assets including SOL, mSOL, BTC, ETH, RAY, SRM, and FTT (more to come).
+ - [GDEX Pro](https://trade.btnomb.com) - Solana trading terminal with Apple Pay on-ramp, sub-second confirmations, and Base L2 USDC
  
  ## Lending Protocol
  - [Apricot Finance](https://apricot.one/) - Next-gen lending protocol on SOLANA. Apricot helps you maximize yield & minimize risk with Apricot Lend, X-Farm and Apricot Assist.


### PR DESCRIPTION
## Summary

GDEX Pro is a Solana trading terminal with Apple Pay on-ramp, sub-second trade confirmations via Base L2 USDC. Fast mobile-first DEX experience.

**URL:** https://trade.btnomb.com

Added under the existing "DeFi" section alongside other Solana DEX/trading protocols.